### PR TITLE
Upgrade react-redux

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "mocha-sugar-free": "^1.3.1",
     "react": "^15.2.1",
     "react-dom": "^15.2.1",
-    "react-redux": "^4.4.5",
+    "react-redux": "^5.0.0",
     "redux": "^3.5.2",
     "rimraf": "^2.5.3"
   },
@@ -44,7 +44,7 @@
     "react": "^0.14.0 || ^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0",
     "redux": "^3.0.0",
-    "react-redux": "^4.0.0"
+    "react-redux": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
     "immutable": "^3.8.1"


### PR DESCRIPTION
This PR introduces following changes:
  - update dev dependency;
  - update peer dependency.


#### Purpose

Allow to use react-redux v5 since it has no breaking changes to public
API and was released as major update due to amount of internal changes.

More details can be found in [`react-redux@5.0.0` changelog](https://github.com/reactjs/react-redux/releases/tag/v5.0.0).


#### Additional information

We are using `redux-audio` with `react-redux@5.0.2` and did not encounter any compatibility problems.